### PR TITLE
feat(ifFeature): added ifFeature support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Available from the `npm` package registry with
 
     const keepLink = new KeepLink()
 
+    // if you want to use ifFeature conditions, add also the following line, otherwise skip it:
+    keepLink.setEnabledFeatures([ 'feature1' ])
+
     const apolloClient = new ApolloClient({
       link: from([
         keepLink,
@@ -59,5 +62,43 @@ query someQuery($argValue: String! $shouldKeep: Boolean!) {
 
 If `$shouldKeep` in this example is `false`, it will remove the whole `field` query including arguments.
 It will also clean up all variables that might be used (if not used by other fields).
+
+If you have a query that is used in multiple components and needs to include a certain field everywhere,
+you can use `ifFeature` instead of `if` as:
+
+```graphql
+query someQuery($argValue: String!) {
+      someOther {
+        subFieldOther(someArg: $argValue) {
+          subSubFieldOther
+        }
+      }
+      field(someArg: $argValue) @keep(ifFeature: "feature1") {
+        subFieldA
+        subFieldB
+      }
+}
+```
+
+It will work exactly the same way as `$shouldKeep` in the previous example. With this approach you just save time 
+as you do not need to pass the same variables to all query use cases.
+
+It is also possible to combine `if` and `ifFeature`:
+
+```graphql
+query someQuery($argValue: String! $shouldKeep: Boolean!) {
+      someOther {
+        subFieldOther(someArg: $argValue) {
+          subSubFieldOther
+        }
+      }
+      field(someArg: $argValue) @keep(if: $shouldKeep ifFeature: "feature1") {
+        subFieldA
+        subFieldB
+      }
+}
+```
+
+In this case the fields will only be included if both `$shouldKeep` is true and `feature1` is enabled.
 
 To prevent Apollo Cache issues it will fill the field with `null` when returned from the server.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Available from the `npm` package registry with
     const keepLink = new KeepLink()
 
     // if you want to use ifFeature conditions, add also the following line, otherwise skip it:
-    keepLink.setEnabledFeatures([ 'feature1' ])
+    keepLink.enabledFeatures = [ 'feature1' ]
 
     const apolloClient = new ApolloClient({
       link: from([

--- a/src/apollo/KeepLink.ts
+++ b/src/apollo/KeepLink.ts
@@ -64,9 +64,9 @@ export function removeIgnoreSetsFromDocument<T extends DocumentNode>(
 }
 
 export class KeepLink extends ApolloLink {
-  _enabledFeatures: Array<string> = []
+  private _enabledFeatures: string[] = []
 
-  setEnabledFeatures(features: Array<string>): void {
+  public set enabledFeatures(features: string[]) {
     this._enabledFeatures = features
   }
 

--- a/src/apollo/KeepLink.ts
+++ b/src/apollo/KeepLink.ts
@@ -16,7 +16,7 @@ import {
 export const DIRECTIVE = 'keep'
 
 interface DirectiveArguments extends Record<string, any> {
-  if?: boolean,
+  if?: boolean
   ifFeature?: string
 }
 
@@ -40,7 +40,10 @@ export function removeIgnoreSetsFromDocument<T extends DocumentNode>(
               variables
             )
             if (args.ifFeature !== undefined && args.if !== undefined) {
-              return !(args.if === true && enabledFeatures.indexOf(args.ifFeature) !== -1)
+              return !(
+                args.if === true &&
+                enabledFeatures.indexOf(args.ifFeature) !== -1
+              )
             }
             if (args.ifFeature) {
               return enabledFeatures.indexOf(args.ifFeature) === -1

--- a/src/apollo/__tests__/KeepLink.spec.ts
+++ b/src/apollo/__tests__/KeepLink.spec.ts
@@ -16,15 +16,23 @@ describe('KeepLink with if', () => {
     }
   `
   it('should remove directives and fields if shouldKeep is false', () => {
-    const { modifiedDoc } = removeIgnoreSetsFromDocument(query, {
-      shouldKeep: false,
-    }, [])
+    const { modifiedDoc } = removeIgnoreSetsFromDocument(
+      query,
+      {
+        shouldKeep: false,
+      },
+      []
+    )
     expect(print(modifiedDoc)).toMatchSnapshot()
   })
   it('should should keep fields, but remove directives if shouldKeep is true', () => {
-    const { modifiedDoc } = removeIgnoreSetsFromDocument(query, {
-      shouldKeep: true,
-    }, [])
+    const { modifiedDoc } = removeIgnoreSetsFromDocument(
+      query,
+      {
+        shouldKeep: true,
+      },
+      []
+    )
     expect(print(modifiedDoc)).toMatchSnapshot()
   })
 
@@ -55,17 +63,21 @@ describe('KeepLink with if', () => {
     `
 
     it('should remove argument variables if exists', () => {
-      const { modifiedDoc } = removeIgnoreSetsFromDocument(queryWithArgument, {
-        shouldKeep: false,
-        argValue: 'test',
-      }, [])
+      const { modifiedDoc } = removeIgnoreSetsFromDocument(
+        queryWithArgument,
+        {
+          shouldKeep: false,
+          argValue: 'test',
+        },
+        []
+      )
       expect(print(modifiedDoc)).toMatchSnapshot()
     })
     it('should keep variables if they are used elsewhere', () => {
       const { modifiedDoc } = removeIgnoreSetsFromDocument(
-          queryWithArgumentAndUsedElsewhere,
-          { shouldKeep: false, argValue: 'test' },
-          []
+        queryWithArgumentAndUsedElsewhere,
+        { shouldKeep: false, argValue: 'test' },
+        []
       )
       expect(print(modifiedDoc)).toMatchSnapshot()
     })
@@ -90,9 +102,9 @@ describe('KeepLink with if', () => {
       }
     `
     const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-        deeperQuery,
-        { shouldKeep: false, argValue: 'test' },
-        []
+      deeperQuery,
+      { shouldKeep: false, argValue: 'test' },
+      []
     )
     expect(nullFields).toEqual([['field', 'subFieldB', 'deep']])
     expect(print(modifiedDoc)).toMatchSnapshot()
@@ -100,7 +112,7 @@ describe('KeepLink with if', () => {
 
   describe('Fragment', () => {
     const someFragment = gql`
-      fragment queryFragment on Type {
+      fragment ifQueryFragment on Type {
         arg @keep(if: $shouldKeep) {
           test
         }
@@ -110,7 +122,7 @@ describe('KeepLink with if', () => {
       query someQuery($shouldKeep: Boolean!) {
         deeply {
           nested {
-            ...queryFragment
+            ...ifQueryFragment
           }
         }
       }
@@ -119,9 +131,9 @@ describe('KeepLink with if', () => {
 
     it('should work with fragments', () => {
       const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-          fragmentQuery,
-          { shouldKeep: false },
-          []
+        fragmentQuery,
+        { shouldKeep: false },
+        []
       )
       expect(nullFields).toEqual([['deeply', 'nested', 'arg']])
       expect(print(modifiedDoc)).toMatchSnapshot()
@@ -130,7 +142,7 @@ describe('KeepLink with if', () => {
 
   describe('Aliases', () => {
     const someFragment = gql`
-      fragment someOtherFragment on Type {
+      fragment someOtherIfFragment on Type {
         aliasForSome: some @keep(if: $shouldKeep) {
           test
         }
@@ -140,7 +152,7 @@ describe('KeepLink with if', () => {
       query someQuery($shouldKeep: Boolean!) {
         aliasForDeeply: deeply {
           nested {
-            ...someOtherFragment
+            ...someOtherIfFragment
           }
         }
       }
@@ -149,9 +161,9 @@ describe('KeepLink with if', () => {
 
     it('should properly map aliases', () => {
       const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-          fragmentQuery,
-          { shouldKeep: false },
-          []
+        fragmentQuery,
+        { shouldKeep: false },
+        []
       )
       expect(nullFields).toEqual([['aliasForDeeply', 'nested', 'aliasForSome']])
       expect(print(modifiedDoc)).toMatchSnapshot()
@@ -168,9 +180,9 @@ describe('KeepLink with if', () => {
       }
     `
     const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-        queryThatWillBeEmpty,
-        { shouldKeep: false },
-        []
+      queryThatWillBeEmpty,
+      { shouldKeep: false },
+      []
     )
 
     expect(nullFields).toEqual([['field']])
@@ -179,7 +191,7 @@ describe('KeepLink with if', () => {
 })
 
 describe('KeepLink with ifFeature', () => {
-  const features = [ 'feature1' ]
+  const features = ['feature1']
   const query = gql`
     query someQuery {
       test {
@@ -227,16 +239,20 @@ describe('KeepLink with ifFeature', () => {
     `
 
     it('should remove argument variables if exists', () => {
-      const { modifiedDoc } = removeIgnoreSetsFromDocument(queryWithArgument, {
-        argValue: 'test',
-      }, [])
+      const { modifiedDoc } = removeIgnoreSetsFromDocument(
+        queryWithArgument,
+        {
+          argValue: 'test',
+        },
+        []
+      )
       expect(print(modifiedDoc)).toMatchSnapshot()
     })
     it('should keep variables if they are used elsewhere', () => {
       const { modifiedDoc } = removeIgnoreSetsFromDocument(
-          queryWithArgumentAndUsedElsewhere,
-          { argValue: 'test' },
-          []
+        queryWithArgumentAndUsedElsewhere,
+        { argValue: 'test' },
+        []
       )
       expect(print(modifiedDoc)).toMatchSnapshot()
     })
@@ -261,9 +277,9 @@ describe('KeepLink with ifFeature', () => {
       }
     `
     const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-        deeperQuery,
-        { argValue: 'test' },
-        []
+      deeperQuery,
+      { argValue: 'test' },
+      []
     )
     expect(nullFields).toEqual([['field', 'subFieldB', 'deep']])
     expect(print(modifiedDoc)).toMatchSnapshot()
@@ -271,7 +287,7 @@ describe('KeepLink with ifFeature', () => {
 
   describe('Fragment', () => {
     const someFragment = gql`
-      fragment queryFragment on Type {
+      fragment ifFeatureQueryFragment on Type {
         arg @keep(ifFeature: "feature1") {
           test
         }
@@ -281,7 +297,7 @@ describe('KeepLink with ifFeature', () => {
       query someQuery {
         deeply {
           nested {
-            ...queryFragment
+            ...ifFeatureQueryFragment
           }
         }
       }
@@ -290,9 +306,9 @@ describe('KeepLink with ifFeature', () => {
 
     it('should work with fragments', () => {
       const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-          fragmentQuery,
-          {},
-          []
+        fragmentQuery,
+        {},
+        []
       )
       expect(nullFields).toEqual([['deeply', 'nested', 'arg']])
       expect(print(modifiedDoc)).toMatchSnapshot()
@@ -301,7 +317,7 @@ describe('KeepLink with ifFeature', () => {
 
   describe('Aliases', () => {
     const someFragment = gql`
-      fragment someOtherFragment on Type {
+      fragment someOtherIfFeatureFragment on Type {
         aliasForSome: some @keep(ifFeature: "feature1") {
           test
         }
@@ -311,7 +327,7 @@ describe('KeepLink with ifFeature', () => {
       query someQuery {
         aliasForDeeply: deeply {
           nested {
-            ...someOtherFragment
+            ...someOtherIfFeatureFragment
           }
         }
       }
@@ -320,9 +336,9 @@ describe('KeepLink with ifFeature', () => {
 
     it('should properly map aliases', () => {
       const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-          fragmentQuery,
-          {},
-          []
+        fragmentQuery,
+        {},
+        []
       )
       expect(nullFields).toEqual([['aliasForDeeply', 'nested', 'aliasForSome']])
       expect(print(modifiedDoc)).toMatchSnapshot()
@@ -339,9 +355,9 @@ describe('KeepLink with ifFeature', () => {
       }
     `
     const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
-        queryThatWillBeEmpty,
-        {},
-        []
+      queryThatWillBeEmpty,
+      {},
+      []
     )
 
     expect(nullFields).toEqual([['field']])

--- a/src/apollo/__tests__/KeepLink.spec.ts
+++ b/src/apollo/__tests__/KeepLink.spec.ts
@@ -25,7 +25,7 @@ describe('KeepLink with if', () => {
     )
     expect(print(modifiedDoc)).toMatchSnapshot()
   })
-  it('should should keep fields, but remove directives if shouldKeep is true', () => {
+  it('should keep fields, but remove directives if shouldKeep is true', () => {
     const { modifiedDoc } = removeIgnoreSetsFromDocument(
       query,
       {
@@ -207,7 +207,7 @@ describe('KeepLink with ifFeature', () => {
     const { modifiedDoc } = removeIgnoreSetsFromDocument(query, {}, [])
     expect(print(modifiedDoc)).toMatchSnapshot()
   })
-  it('should should keep fields, but remove directives if feature1 is enabled', () => {
+  it('should keep fields, but remove directives if feature1 is enabled', () => {
     const { modifiedDoc } = removeIgnoreSetsFromDocument(query, {}, features)
     expect(print(modifiedDoc)).toMatchSnapshot()
   })
@@ -357,6 +357,198 @@ describe('KeepLink with ifFeature', () => {
     const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
       queryThatWillBeEmpty,
       {},
+      []
+    )
+
+    expect(nullFields).toEqual([['field']])
+    expect(modifiedDoc).toBe(null)
+  })
+})
+
+describe('KeepLink with if and ifFeature', () => {
+  const features = ['feature1']
+  const query = gql`
+    query someQuery($shouldKeep: Boolean!) {
+      test {
+        some
+      }
+      field @keep(if: $shouldKeep, ifFeature: "feature1") {
+        subFieldA
+        subFieldB
+      }
+    }
+  `
+  it('should remove directives and fields if shouldKeep is false and feature1 is not enabled', () => {
+    const { modifiedDoc } = removeIgnoreSetsFromDocument(
+      query,
+      {
+        shouldKeep: false,
+      },
+      []
+    )
+    expect(print(modifiedDoc)).toMatchSnapshot()
+  })
+  it('should keep fields, but remove directives if shouldKeep is true and feature1 is enabled', () => {
+    const { modifiedDoc } = removeIgnoreSetsFromDocument(
+      query,
+      {
+        shouldKeep: true,
+      },
+      features
+    )
+    expect(print(modifiedDoc)).toMatchSnapshot()
+  })
+
+  describe('Field Arguments', () => {
+    const queryWithArgument = gql`
+      query someQuery($argValue: String!, $shouldKeep: Boolean!) {
+        someOther {
+          subFieldOther
+        }
+        field(someArg: $argValue)
+          @keep(if: $shouldKeep, ifFeature: "feature1") {
+          subFieldA
+          subFieldB
+        }
+      }
+    `
+    const queryWithArgumentAndUsedElsewhere = gql`
+      query someQuery($argValue: String!, $shouldKeep: Boolean!) {
+        someOther {
+          subFieldOther(someArg: $argValue) {
+            subSubFieldOther
+          }
+        }
+        field(someArg: $argValue)
+          @keep(if: $shouldKeep, ifFeature: "feature1") {
+          subFieldA
+          subFieldB
+        }
+      }
+    `
+
+    it('should remove argument variables if exists', () => {
+      const { modifiedDoc } = removeIgnoreSetsFromDocument(
+        queryWithArgument,
+        {
+          shouldKeep: false,
+          argValue: 'test',
+        },
+        []
+      )
+      expect(print(modifiedDoc)).toMatchSnapshot()
+    })
+    it('should keep variables if they are used elsewhere', () => {
+      const { modifiedDoc } = removeIgnoreSetsFromDocument(
+        queryWithArgumentAndUsedElsewhere,
+        { shouldKeep: false, argValue: 'test' },
+        []
+      )
+      expect(print(modifiedDoc)).toMatchSnapshot()
+    })
+  })
+
+  describe('Deep Fields', () => {
+    const deeperQuery = gql`
+      query someQuery($argValue: String!, $shouldKeep: Boolean!) {
+        someOther {
+          subFieldOther
+        }
+        field {
+          subFieldA
+          subFieldB {
+            deep(someArg: $argValue)
+              @keep(if: $shouldKeep, ifFeature: "feature1") {
+              test {
+                wow
+              }
+            }
+          }
+        }
+      }
+    `
+    const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
+      deeperQuery,
+      { shouldKeep: false, argValue: 'test' },
+      []
+    )
+    expect(nullFields).toEqual([['field', 'subFieldB', 'deep']])
+    expect(print(modifiedDoc)).toMatchSnapshot()
+  })
+
+  describe('Fragment', () => {
+    const someFragment = gql`
+      fragment ifAndIfFeatureQueryFragment on Type {
+        arg @keep(if: $shouldKeep, ifFeature: "feature1") {
+          test
+        }
+      }
+    `
+    const fragmentQuery = gql`
+      query someQuery($shouldKeep: Boolean!) {
+        deeply {
+          nested {
+            ...ifAndIfFeatureQueryFragment
+          }
+        }
+      }
+      ${someFragment}
+    `
+
+    it('should work with fragments', () => {
+      const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
+        fragmentQuery,
+        { shouldKeep: false },
+        []
+      )
+      expect(nullFields).toEqual([['deeply', 'nested', 'arg']])
+      expect(print(modifiedDoc)).toMatchSnapshot()
+    })
+  })
+
+  describe('Aliases', () => {
+    const someFragment = gql`
+      fragment someOtherIfAndIfFeatureFragment on Type {
+        aliasForSome: some @keep(if: $shouldKeep, ifFeature: "feature1") {
+          test
+        }
+      }
+    `
+    const fragmentQuery = gql`
+      query someQuery($shouldKeep: Boolean!) {
+        aliasForDeeply: deeply {
+          nested {
+            ...someOtherIfAndIfFeatureFragment
+          }
+        }
+      }
+      ${someFragment}
+    `
+
+    it('should properly map aliases', () => {
+      const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
+        fragmentQuery,
+        { shouldKeep: false },
+        []
+      )
+      expect(nullFields).toEqual([['aliasForDeeply', 'nested', 'aliasForSome']])
+      expect(print(modifiedDoc)).toMatchSnapshot()
+    })
+  })
+
+  describe('Empty documents', () => {
+    const queryThatWillBeEmpty = gql`
+      query someQuery($argValue: String!, $shouldKeep: Boolean!) {
+        field(someArg: $argValue)
+          @keep(if: $shouldKeep, ifFeature: "feature1") {
+          subFieldA
+          subFieldB
+        }
+      }
+    `
+    const { modifiedDoc, nullFields } = removeIgnoreSetsFromDocument(
+      queryThatWillBeEmpty,
+      { shouldKeep: false },
       []
     )
 

--- a/src/apollo/__tests__/__snapshots__/KeepLink.spec.ts.snap
+++ b/src/apollo/__tests__/__snapshots__/KeepLink.spec.ts.snap
@@ -13,20 +13,33 @@ exports[` 1`] = `
 "
 `;
 
-exports[`KeepLink Aliases should properly map aliases 1`] = `
+exports[` 2`] = `
+"query someQuery {
+  someOther {
+    subFieldOther
+  }
+  field {
+    subFieldA
+    subFieldB
+  }
+}
+"
+`;
+
+exports[`KeepLink with if Aliases should properly map aliases 1`] = `
 "query someQuery {
   aliasForDeeply: deeply {
     nested {
-      ...someOtherFragment
+      ...someOtherIfFragment
     }
   }
 }
 
-fragment someOtherFragment on Type 
+fragment someOtherIfFragment on Type 
 "
 `;
 
-exports[`KeepLink Field Arguments should keep variables if they are used elsewhere 1`] = `
+exports[`KeepLink with if Field Arguments should keep variables if they are used elsewhere 1`] = `
 "query someQuery($argValue: String!) {
   someOther {
     subFieldOther(someArg: $argValue) {
@@ -37,7 +50,7 @@ exports[`KeepLink Field Arguments should keep variables if they are used elsewhe
 "
 `;
 
-exports[`KeepLink Field Arguments should remove argument variables if exists 1`] = `
+exports[`KeepLink with if Field Arguments should remove argument variables if exists 1`] = `
 "query someQuery {
   someOther {
     subFieldOther
@@ -46,20 +59,20 @@ exports[`KeepLink Field Arguments should remove argument variables if exists 1`]
 "
 `;
 
-exports[`KeepLink Fragment should work with fragments 1`] = `
+exports[`KeepLink with if Fragment should work with fragments 1`] = `
 "query someQuery {
   deeply {
     nested {
-      ...queryFragment
+      ...ifQueryFragment
     }
   }
 }
 
-fragment queryFragment on Type 
+fragment ifQueryFragment on Type 
 "
 `;
 
-exports[`KeepLink should remove directives and fields if shouldKeep is false 1`] = `
+exports[`KeepLink with if should remove directives and fields if shouldKeep is false 1`] = `
 "query someQuery {
   test {
     some
@@ -68,7 +81,75 @@ exports[`KeepLink should remove directives and fields if shouldKeep is false 1`]
 "
 `;
 
-exports[`KeepLink should should keep fields, but remove directives if shouldKeep is true 1`] = `
+exports[`KeepLink with if should should keep fields, but remove directives if shouldKeep is true 1`] = `
+"query someQuery {
+  test {
+    some
+  }
+  field {
+    subFieldA
+    subFieldB
+  }
+}
+"
+`;
+
+exports[`KeepLink with ifFeature Aliases should properly map aliases 1`] = `
+"query someQuery {
+  aliasForDeeply: deeply {
+    nested {
+      ...someOtherIfFeatureFragment
+    }
+  }
+}
+
+fragment someOtherIfFeatureFragment on Type 
+"
+`;
+
+exports[`KeepLink with ifFeature Field Arguments should keep variables if they are used elsewhere 1`] = `
+"query someQuery($argValue: String!) {
+  someOther {
+    subFieldOther(someArg: $argValue) {
+      subSubFieldOther
+    }
+  }
+}
+"
+`;
+
+exports[`KeepLink with ifFeature Field Arguments should remove argument variables if exists 1`] = `
+"query someQuery {
+  someOther {
+    subFieldOther
+  }
+}
+"
+`;
+
+exports[`KeepLink with ifFeature Fragment should work with fragments 1`] = `
+"query someQuery {
+  deeply {
+    nested {
+      ...ifFeatureQueryFragment
+    }
+  }
+}
+
+fragment ifFeatureQueryFragment on Type 
+"
+`;
+
+exports[`KeepLink with ifFeature should remove directives and fields if feature1 is not enabled 1`] = `
+"query someQuery {
+  test {
+    some
+  }
+}
+"
+`;
+
+exports[`KeepLink with ifFeature should should keep fields, but remove directives if feature1 is enabled 1`] = `
 "query someQuery {
   test {
     some

--- a/src/apollo/__tests__/__snapshots__/KeepLink.spec.ts.snap
+++ b/src/apollo/__tests__/__snapshots__/KeepLink.spec.ts.snap
@@ -26,6 +26,19 @@ exports[` 2`] = `
 "
 `;
 
+exports[` 3`] = `
+"query someQuery {
+  someOther {
+    subFieldOther
+  }
+  field {
+    subFieldA
+    subFieldB
+  }
+}
+"
+`;
+
 exports[`KeepLink with if Aliases should properly map aliases 1`] = `
 "query someQuery {
   aliasForDeeply: deeply {
@@ -72,7 +85,66 @@ fragment ifQueryFragment on Type
 "
 `;
 
-exports[`KeepLink with if should remove directives and fields if shouldKeep is false 1`] = `
+exports[`KeepLink with if and ifFeature Aliases should properly map aliases 1`] = `
+"query someQuery {
+  aliasForDeeply: deeply {
+    nested {
+      ...someOtherIfAndIfFeatureFragment
+    }
+  }
+}
+
+fragment someOtherIfAndIfFeatureFragment on Type 
+"
+`;
+
+exports[`KeepLink with if and ifFeature Field Arguments should keep variables if they are used elsewhere 1`] = `
+"query someQuery($argValue: String!) {
+  someOther {
+    subFieldOther(someArg: $argValue) {
+      subSubFieldOther
+    }
+  }
+}
+"
+`;
+
+exports[`KeepLink with if and ifFeature Field Arguments should remove argument variables if exists 1`] = `
+"query someQuery {
+  someOther {
+    subFieldOther
+  }
+}
+"
+`;
+
+exports[`KeepLink with if and ifFeature Fragment should work with fragments 1`] = `
+"query someQuery {
+  deeply {
+    nested {
+      ...ifAndIfFeatureQueryFragment
+    }
+  }
+}
+
+fragment ifAndIfFeatureQueryFragment on Type 
+"
+`;
+
+exports[`KeepLink with if and ifFeature should keep fields, but remove directives if shouldKeep is true and feature1 is enabled 1`] = `
+"query someQuery {
+  test {
+    some
+  }
+  field {
+    subFieldA
+    subFieldB
+  }
+}
+"
+`;
+
+exports[`KeepLink with if and ifFeature should remove directives and fields if shouldKeep is false and feature1 is not enabled 1`] = `
 "query someQuery {
   test {
     some
@@ -81,7 +153,7 @@ exports[`KeepLink with if should remove directives and fields if shouldKeep is f
 "
 `;
 
-exports[`KeepLink with if should should keep fields, but remove directives if shouldKeep is true 1`] = `
+exports[`KeepLink with if should keep fields, but remove directives if shouldKeep is true 1`] = `
 "query someQuery {
   test {
     some
@@ -89,6 +161,15 @@ exports[`KeepLink with if should should keep fields, but remove directives if sh
   field {
     subFieldA
     subFieldB
+  }
+}
+"
+`;
+
+exports[`KeepLink with if should remove directives and fields if shouldKeep is false 1`] = `
+"query someQuery {
+  test {
+    some
   }
 }
 "
@@ -140,16 +221,7 @@ fragment ifFeatureQueryFragment on Type
 "
 `;
 
-exports[`KeepLink with ifFeature should remove directives and fields if feature1 is not enabled 1`] = `
-"query someQuery {
-  test {
-    some
-  }
-}
-"
-`;
-
-exports[`KeepLink with ifFeature should should keep fields, but remove directives if feature1 is enabled 1`] = `
+exports[`KeepLink with ifFeature should keep fields, but remove directives if feature1 is enabled 1`] = `
 "query someQuery {
   test {
     some
@@ -157,6 +229,15 @@ exports[`KeepLink with ifFeature should should keep fields, but remove directive
   field {
     subFieldA
     subFieldB
+  }
+}
+"
+`;
+
+exports[`KeepLink with ifFeature should remove directives and fields if feature1 is not enabled 1`] = `
+"query someQuery {
+  test {
+    some
   }
 }
 "


### PR DESCRIPTION
This feature allows to get rid of variables in if condition if the same field should be included into all query use cases.

(!) There is something wrong with tests, lint fails without specifying any details:
src/apollo/__tests__/KeepLink.spec.ts
src/apollo/KeepLink.ts
ERROR: "test:lint" exited with 1.